### PR TITLE
Updated GPG keys and their respective URLs.

### DIFF
--- a/playbook/playbook.yaml
+++ b/playbook/playbook.yaml
@@ -143,7 +143,7 @@
   - name: Install pip
     become: yes
     apt:
-      name: python3-pip_23.0.1
+      name: python3-pip_23.0.1*
       state: present
       update_cache: yes
   - name: Install InfluxDB client library

--- a/playbook/playbook.yaml
+++ b/playbook/playbook.yaml
@@ -143,7 +143,7 @@
   - name: Install pip
     become: yes
     apt:
-      name: python3-pip=20.3.4*
+      name: python3-pip_23.0.1
       state: present
       update_cache: yes
   - name: Install InfluxDB client library

--- a/playbook/playbook.yaml
+++ b/playbook/playbook.yaml
@@ -149,7 +149,7 @@
   - name: Install InfluxDB client library
     become: yes
     ansible.builtin.pip:
-      name: influxdb-client==1.33.0
+      name: influxdb-client==1.6.7
   - name: Copy speedtest script
     become: yes
     ansible.builtin.copy:

--- a/playbook/playbook.yaml
+++ b/playbook/playbook.yaml
@@ -149,7 +149,8 @@
   - name: Install InfluxDB client library
     become: yes
     ansible.builtin.pip:
-      name: influxdb-client==1.6.7
+      name: influxdb-client==1.38
+      extra_args: '--break-system-packages'
   - name: Copy speedtest script
     become: yes
     ansible.builtin.copy:

--- a/playbook/playbook.yaml
+++ b/playbook/playbook.yaml
@@ -8,8 +8,8 @@
   - name: Add InfluxDB apt key
     become: yes
     apt_key: 
-      url: https://repos.influxdata.com/influxdb.key
-      id: 05CE15085FC09D18E99EFB22684A14CF2582E0C5
+      url: https://repos.influxdata.com/influxdata-archive_compat.key
+      id: 9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E
       state: present
       keyring: /etc/apt/trusted.gpg.d/influxdb.gpg
   - name: Add InfluxDB apt repository
@@ -31,8 +31,8 @@
   - name: Add Grafana apt key
     become: yes
     apt_key: 
-      url: https://packages.grafana.com/gpg.key
-      id: 4E40DDF6D76E284A4A6780E48C8C34C524098CB6
+      url: https://apt.grafana.com/gpg.key
+      id: B53AE77BADB630A683046005963FA27710458545
       state: present
       keyring: /usr/share/keyrings/grafana.key
   - name: Add Grafana apt repository


### PR DESCRIPTION
The old GPG Keys were expired and didn't work any longer. These should work. URLs have changed in some cases, too.