### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This tool runs an [Ansible][ansible] playbook in a [Docker][docker] container to
     # SSH_KEY=~/.ssh/id_rsa   [Location of the SSH private key]
     # CRON='*/30 * * * *'     [Speedtest interval (Every 30 minutes)]
 
-    $ make [HOST='...'] [SSH_USER='...'] [SSH_KEY='...'] [CRON='...']
+    $ make HOST='...' SSH_USER='...' SSH_KEY='...' CRON='...'
     ```
 
     ## Preview


### PR DESCRIPTION
The brackets in the make command seem to cause parsing errors in ZSH (zsh: no matches found: [HOST='test.local']). Just omitting those seems to work fine.